### PR TITLE
Fixed error with missing add-apt-repository

### DIFF
--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -58,6 +58,8 @@ Vagrant.configure("2") do |config|
     tar xzvf /tmp/pin-2.11-49306-gcc.3.4.6-ia32_intel64-linux.tar.gz -C /opt
 
     #Install STP, ipython and iltrans dependencies
+    apt-get update
+    apt-get install --force-yes -y python-software-properties
     add-apt-repository -y ppa:simple-theorem-prover
     apt-get update
     apt-get install --force-yes -y ipython stp libprotobuf7 libcamomile-ocaml-data python-py python-faulthandler


### PR DESCRIPTION
The command add-apt-repository was missing, which led to stp never getting installed.
OpenSAW started fine without it, but never actually calculated any new inputs when I was running it.